### PR TITLE
Adds template validation (on creation/update)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -20,8 +20,9 @@ servers:
       port:
         description: The port all API requests listen on.
         enum:
+          - '9093'
           - '8181'
-        default: '8181'
+        default: '9093'
 tags:
   - name: mails
     description: Mail Service
@@ -385,11 +386,13 @@ components:
             A keyed description of the error. We do not write human readable text here because the user interface will be multi language.
             
             At this time, there are these values:
+            - mail.data.invalid (given data is not plausible)
             - mail.server.error (mail server failure while sending email)
+            - mail.parse.error (json body parse error)
+            - template.invalid.error (given data is not plausible)
+            - template.database.error (problem with database)
+            - template.notfound.error (template does not exist in database)
             - template.parse.error (json body parse error)
-            - template.database.error
-            - template.notfound.error
-            - template.invalid.error
           example: mail.server.error
         details:
           type: array

--- a/internal/web/controller/mailctl/validation.go
+++ b/internal/web/controller/mailctl/validation.go
@@ -17,7 +17,7 @@ func validate(ctx context.Context, a *mail.MailSendDto) url.Values {
 
 	validation.CheckLength(&errs, 1, 5, "lang", a.Lang)
 	if validation.ViolatesPattern(langPattern, a.Lang) {
-		errs.Add("lang", "language field is not plausible, must match "+emailPattern)
+		errs.Add("lang", "language field is not plausible, must match "+langPattern+" (e.g.: de-DE)")
 	}
 
 	if len(a.To) > 0 {

--- a/internal/web/controller/templatectl/validation.go
+++ b/internal/web/controller/templatectl/validation.go
@@ -1,0 +1,43 @@
+package templatectl
+
+import (
+	"context"
+	aulogging "github.com/StephanHCB/go-autumn-logging"
+	"github.com/eurofurence/reg-mail-service/internal/api/v1/template"
+	"github.com/eurofurence/reg-mail-service/internal/repository/config"
+	"github.com/eurofurence/reg-mail-service/internal/web/util/validation"
+	"net/url"
+)
+
+const langPattern = "^[a-z]{2}-[A-Z]{2}$"
+
+func validate(ctx context.Context, a *template.TemplateDto) url.Values {
+	errs := url.Values{}
+
+	validation.CheckLength(&errs, 1, 5, "lang", a.Lang)
+	if validation.ViolatesPattern(langPattern, a.Lang) {
+		errs.Add("lang", "language field is not plausible, must match "+langPattern+" (e.g.: de-DE)")
+	}
+
+	if len(a.CommonID) < 1 {
+		errs.Add("template", "CommonID cannot be empty")
+	}
+
+	if len(a.Subject) < 1 {
+		errs.Add("template", "Subject cannot be empty")
+	}
+
+	if len(a.Data) < 1 {
+		errs.Add("template", "Data cannot be empty")
+	}
+
+	if len(errs) != 0 {
+		if config.LoggingSeverity() == "DEBUG" {
+			logger := aulogging.Logger.Ctx(ctx).Debug()
+			for key, val := range errs {
+				logger.Printf("template dto validation error for key %s: %s", key, val)
+			}
+		}
+	}
+	return errs
+}


### PR DESCRIPTION
The correct regex pattern will be now displayed in the validation error of the mail template, if the language field did not match the regex.

Additionally updates OpenAPI spec:
- Default port matches to default config
- Added missing error values in ErrorDto schema

(I also wanted to try out the CodeQL Workflow and there is unfortunately no button to manually trigger it)