### PR TITLE
Adds more development related config options

### DIFF
--- a/docs/config.example.yaml
+++ b/docs/config.example.yaml
@@ -1,6 +1,11 @@
 server:
   port: 9093
 mail:
+  log_only: false # Only log the E-Mail (Requires logging to be set to DEBUG). No sending.
+  dev_mode: false # Override the recipient (To) to the list below, ignore Bcc/Cc.
+  dev_mails:
+    - 'developer@example.com'
+    - 'another.dev@example.com'
   from: 'no-reply@example.com' # Sender E-Mail Address
   from_password: 'email-account-password' # Sender E-Mail Passwor
   smtp_host: 'mail.example.com' # Mailserver Host

--- a/internal/repository/config/config.go
+++ b/internal/repository/config/config.go
@@ -28,6 +28,18 @@ func ServerIdleTimeout() time.Duration {
 	return time.Second * time.Duration(Configuration().Server.IdleTimeout)
 }
 
+func MailLogOnly() bool {
+	return configurationData.Mail.LogOnly
+}
+
+func MailDevMode() bool {
+	return configurationData.Mail.DevMode
+}
+
+func MailDevMails() []string {
+	return configurationData.Mail.DevMails
+}
+
 func EmailFrom() string {
 	return configurationData.Mail.From
 }

--- a/internal/repository/config/structure.go
+++ b/internal/repository/config/structure.go
@@ -73,10 +73,13 @@ type (
 
 	// MailConfig contains values for the mail server
 	MailConfig struct {
-		From     string `yaml:"from"`
-		FromPass string `yaml:"from_password"`
-		Host     string `yaml:"smtp_host"`
-		Port     string `yaml:"smtp_port"`
+		LogOnly  bool     `yaml:"log_only"`
+		DevMode  bool     `yaml:"dev_mode"`
+		DevMails []string `yaml:"dev_mails"`
+		From     string   `yaml:"from"`
+		FromPass string   `yaml:"from_password"`
+		Host     string   `yaml:"smtp_host"`
+		Port     string   `yaml:"smtp_port"`
 	}
 )
 


### PR DESCRIPTION
Two new configuration options have been added:

**Log Only**
Setting this to true will not try to authenticate with any mail server, and will not send any email.
It will only log the email body itself into the console.

Note: Logging severity has to be set on `DEBUG` to be able to see the log output.

**Development Mode**
This mode will override the `To` part of the body to a pre-set list of developer emails and ignore any `Cc` and `Bcc` recipients.
It will include the original To, Cc and Bcc to the E-Mail at the bottom, but only the developers will receive said email.