### PR TITLE
feat(#85): add optional message id to emails

### DIFF
--- a/docs/config.example.yaml
+++ b/docs/config.example.yaml
@@ -12,6 +12,7 @@ mail:
   from_password: 'email-account-password' # Sender E-Mail Password
   smtp_host: 'mail.example.com' # Mail-server Host
   smtp_port: '587' # Mail-server Port
+  message_id_domain: 'example.com'
 database:
   use: 'inmemory' # [inmemory, mysql]
   username: 'db-user-username'

--- a/internal/repository/config/config.go
+++ b/internal/repository/config/config.go
@@ -45,6 +45,10 @@ func AddAutoBcc() string {
 	return configurationData.Mail.AddAutoBcc
 }
 
+func MessageIdDomain() string {
+	return configurationData.Mail.MessageIdDomain
+}
+
 func EmailFrom() string {
 	return configurationData.Mail.From
 }

--- a/internal/repository/config/structure.go
+++ b/internal/repository/config/structure.go
@@ -76,14 +76,15 @@ type (
 
 	// MailConfig contains values for the mail server
 	MailConfig struct {
-		LogOnly    bool     `yaml:"log_only"`
-		DevMode    bool     `yaml:"dev_mode"`
-		DevMails   []string `yaml:"dev_mails"`
-		AddAutoBcc string   `yaml:"add_auto_bcc"`
-		From       string   `yaml:"from"`
-		FromPass   string   `yaml:"from_password"`
-		Host       string   `yaml:"smtp_host"`
-		Port       string   `yaml:"smtp_port"`
+		LogOnly         bool     `yaml:"log_only"`
+		DevMode         bool     `yaml:"dev_mode"`
+		DevMails        []string `yaml:"dev_mails"`
+		AddAutoBcc      string   `yaml:"add_auto_bcc"`
+		From            string   `yaml:"from"`
+		FromPass        string   `yaml:"from_password"`
+		Host            string   `yaml:"smtp_host"`
+		Port            string   `yaml:"smtp_port"`
+		MessageIdDomain string   `yaml:"message_id_domain"`
 	}
 )
 


### PR DESCRIPTION
- add optional config field `message_id_domain`
- if set, generate a message ID from millisecond timestamp and 4 byte random hex